### PR TITLE
Add `unidecode` package to Pipfile as a dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 requests = "*"
 bs4 = "*"
 html5lib = "*"
+unidecode = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
This PR fixes the problem of missing dependency in Pipenv. 